### PR TITLE
Bugfix: loading spinner doesn't show when viewing event details page

### DIFF
--- a/src/Components/ViewEvent.js
+++ b/src/Components/ViewEvent.js
@@ -42,7 +42,7 @@ const ViewEventWithData = graphql(
             variables: { id },
             fetchPolicy: 'cache-and-network',
         }),
-        props: ({ data: { getEvent: event }, loading }) => ({
+        props: ({ data: { getEvent: event, loading} }) => ({
             event,
             loading,
         }),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixed bug where loading is always undefined and therefore loading spinner doesn’t show when loading an individual event.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
